### PR TITLE
Reset displayed spindle angle with SET long press

### DIFF
--- a/els-f280049c/UserInterface.h
+++ b/els-f280049c/UserInterface.h
@@ -54,6 +54,9 @@ private:
     bool isInMenu;
     Uint16 menuState, menuSubState;
 
+    Uint16 setHoldTime;
+    bool setHeld;
+
     int numStarts, currentStart;
 
     FeedTable *feedTable;
@@ -62,6 +65,8 @@ private:
 
     const MESSAGE *message;
     Uint16 messageTime;
+
+    Uint16 spindleAngleOffset;
 
     const FEED_THREAD *loadFeedTable();
     LED_REG calculateLEDs();


### PR DESCRIPTION
Currently, spindle angle is displayed relative to the position the spindle was in when the unit was powered on. However, when using the spindle angle display mode, it would sometimes be convenient to be able to set the reference angle. Displaying the angle relative to when entering the spindle angle display mode would be a convenient way to set the index.

(Based on conversation at clough42/electronic-leadscrew#278, thus this PR is currently in draft status because it has not yet been tested. I'll remove the draft state after it is tested.)